### PR TITLE
Update to replace deprecated call with yo hubot generator instead.

### DIFF
--- a/app/models/hubot.rb
+++ b/app/models/hubot.rb
@@ -157,8 +157,8 @@ class Hubot < ActiveRecord::Base
 
     def install
       self.location = File.join(Hubot.base_dir, title.parameterize)
-      log Shell.run("hubot --create #{self.location}")
-      log Shell.run("cd #{self.location} && bin/hubot -v")
+      log Shell.run("mkdir -p #{self.location}")
+      log Shell.run("cd #{self.location} && yo hubot --adapter=#{adapter} --defaults && bin/hubot -v")
     end
 
     def uninstall


### PR DESCRIPTION
Pass in adapter from the UI, default the rest.
